### PR TITLE
feat: add get public projects route

### DIFF
--- a/src/projects/projects.controller.spec.ts
+++ b/src/projects/projects.controller.spec.ts
@@ -46,11 +46,30 @@ describe('ProjectsController', () => {
         .spyOn(projectsService as any, 'getProjects')
         .mockResolvedValue({ results, meta });
 
-      const query = {};
+      const query = new Chance().string();
 
       const res = await controller.getProjects(query as any);
 
-      expect(getProjects).toHaveBeenCalled();
+      expect(getProjects).toHaveBeenCalledWith(query, false);
+      expect(res.results).toEqual(results);
+      expect(res.meta).toEqual(meta);
+    });
+  });
+
+  describe('getPublicProjects', () => {
+    it('Should call the getProjects project service and the send the results and meta as a result', async () => {
+      const results = new Chance().string();
+      const meta = new Chance().string();
+
+      const getProjects = jest
+        .spyOn(projectsService as any, 'getProjects')
+        .mockResolvedValue({ results, meta });
+
+      const query = new Chance().string();
+
+      const res = await controller.getPublicProjects(query as any);
+
+      expect(getProjects).toHaveBeenCalledWith(query, true);
       expect(res.results).toEqual(results);
       expect(res.meta).toEqual(meta);
     });

--- a/src/projects/projects.controller.ts
+++ b/src/projects/projects.controller.ts
@@ -17,11 +17,11 @@ import { AuthGuard } from '../common/auth.guard';
 import { GetProjectsQuery } from './dto/get.dto';
 import { GetProjectByIdParams } from './dto/get-by-id.dto';
 
-@Controller('projects')
+@Controller()
 export class ProjectsController {
   constructor(private projectsService: ProjectsService) {}
 
-  @Post('')
+  @Post('/projects')
   @HttpCode(200)
   @UseGuards(AuthGuard)
   @UseInterceptors(FilesInterceptor('photos'))
@@ -40,14 +40,17 @@ export class ProjectsController {
     return { id: project.id };
   }
 
-  @Get('all')
+  @Get('/projects/all')
   @UseGuards(AuthGuard)
   async getProjects(@Query() query: GetProjectsQuery) {
-    const { results, meta } = await this.projectsService.getProjects(query);
+    const { results, meta } = await this.projectsService.getProjects(
+      query,
+      false,
+    );
     return { results, meta };
   }
 
-  @Get(':id')
+  @Get('/projects/:id')
   @UseGuards(AuthGuard)
   async getProjectById(@Param() params: GetProjectByIdParams) {
     const project = await this.projectsService.getProjectInfo(params.id);

--- a/src/projects/projects.controller.ts
+++ b/src/projects/projects.controller.ts
@@ -50,6 +50,15 @@ export class ProjectsController {
     return { results, meta };
   }
 
+  @Get('/public/projects/all')
+  async getPublicProjects(@Query() query: GetProjectsQuery) {
+    const { results, meta } = await this.projectsService.getProjects(
+      query,
+      true,
+    );
+    return { results, meta };
+  }
+
   @Get('/projects/:id')
   @UseGuards(AuthGuard)
   async getProjectById(@Param() params: GetProjectByIdParams) {

--- a/src/projects/projects.service.spec.ts
+++ b/src/projects/projects.service.spec.ts
@@ -114,10 +114,14 @@ describe('ProjectsService', () => {
           })),
       });
 
-      const simplifiedProjects = await service['getSimplifiedProjects'](25, {
-        page: 1,
-        order: 'newest',
-      });
+      const simplifiedProjects = await service['getSimplifiedProjects'](
+        25,
+        {
+          page: 1,
+          order: 'newest',
+        },
+        {},
+      );
 
       expect(simplifiedProjects).toHaveLength(projectsCount);
       for (const project of simplifiedProjects) {
@@ -138,10 +142,14 @@ describe('ProjectsService', () => {
           })),
       });
 
-      const simplifiedProjects = await service['getSimplifiedProjects'](25, {
-        page: 1,
-        order: 'newest',
-      });
+      const simplifiedProjects = await service['getSimplifiedProjects'](
+        25,
+        {
+          page: 1,
+          order: 'newest',
+        },
+        {},
+      );
 
       expect(simplifiedProjects).toHaveLength(projectsCount);
       for (const project of simplifiedProjects) {
@@ -167,10 +175,14 @@ describe('ProjectsService', () => {
         orderBy: { createdAt: 'desc' },
       });
 
-      const simplifiedProjects = await service['getSimplifiedProjects'](25, {
-        page: 1,
-        order: 'oldest',
-      });
+      const simplifiedProjects = await service['getSimplifiedProjects'](
+        25,
+        {
+          page: 1,
+          order: 'oldest',
+        },
+        {},
+      );
 
       expect(simplifiedProjects).toHaveLength(25);
       expect(simplifiedProjects[0].id).toEqual(allProjects[0].id);
@@ -195,10 +207,14 @@ describe('ProjectsService', () => {
         orderBy: { createdAt: 'desc' },
       });
 
-      const simplifiedProjects = await service['getSimplifiedProjects'](25, {
-        page: 2,
-        order: 'oldest',
-      });
+      const simplifiedProjects = await service['getSimplifiedProjects'](
+        25,
+        {
+          page: 2,
+          order: 'oldest',
+        },
+        {},
+      );
 
       expect(simplifiedProjects).toHaveLength(projectsCount - 25);
       expect(simplifiedProjects[0].id).toEqual(allProjects[25].id);
@@ -290,7 +306,7 @@ describe('ProjectsService', () => {
         .spyOn(service as any, 'getSimplifiedProjects')
         .mockReturnValue({});
 
-      await service['getProjects'](data);
+      await service['getProjects'](data, false);
 
       expect(genPaginationMeta).toHaveBeenCalled();
       expect(getSimplifiedProjects).toHaveBeenCalled();

--- a/src/projects/projects.service.spec.ts
+++ b/src/projects/projects.service.spec.ts
@@ -291,7 +291,7 @@ describe('ProjectsService', () => {
   });
 
   describe('getProjects', () => {
-    it('Should call the genPaginationMeta and getSimplifiedProjects functions', async () => {
+    it('Should call the genPaginationMeta and getSimplifiedProjects functions when the projects do not have to be active', async () => {
       const data = {
         order: new Chance().pickone(['newest', 'oldest']) as
           | 'newest'
@@ -309,7 +309,30 @@ describe('ProjectsService', () => {
       await service['getProjects'](data, false);
 
       expect(genPaginationMeta).toHaveBeenCalled();
-      expect(getSimplifiedProjects).toHaveBeenCalled();
+      expect(getSimplifiedProjects).toHaveBeenCalledWith(25, data, {});
+    });
+
+    it('Should call the genPaginationMeta and getSimplifiedProjects functions with filters when the projects must be active', async () => {
+      const data = {
+        order: new Chance().pickone(['newest', 'oldest']) as
+          | 'newest'
+          | 'oldest',
+        page: new Chance().integer({ min: 1, max: 1000 }),
+      };
+
+      const genPaginationMeta = jest
+        .spyOn(service as any, 'genPaginationMeta')
+        .mockReturnValue({});
+      const getSimplifiedProjects = jest
+        .spyOn(service as any, 'getSimplifiedProjects')
+        .mockReturnValue({});
+
+      await service['getProjects'](data, true);
+
+      expect(genPaginationMeta).toHaveBeenCalled();
+      expect(getSimplifiedProjects).toHaveBeenCalledWith(25, data, {
+        active: true,
+      });
     });
   });
 

--- a/src/projects/projects.service.ts
+++ b/src/projects/projects.service.ts
@@ -75,9 +75,11 @@ export class ProjectsService {
   private async getSimplifiedProjects(
     pageSize: number,
     filters: GetProjectsQuery,
+    prismaFilters: {} | { active: true },
   ) {
     const projects = await this.prisma.projects.findMany({
       take: pageSize,
+      where: prismaFilters,
       skip: pageSize * (filters.page - 1),
       select: {
         id: true,
@@ -109,12 +111,19 @@ export class ProjectsService {
     return formattedProjects;
   }
 
-  async getProjects(filters: GetProjectsQuery) {
+  async getProjects(filters: GetProjectsQuery, mustBeActive: boolean) {
     const pageSize = 25;
 
-    const projectsCount = await this.prisma.projects.count();
+    const prismaFilters = mustBeActive ? { active: true } : {};
+    const projectsCount = await this.prisma.projects.count({
+      where: prismaFilters,
+    });
     const meta = this.genPaginationMeta(filters.page, pageSize, projectsCount);
-    const projects = await this.getSimplifiedProjects(pageSize, filters);
+    const projects = await this.getSimplifiedProjects(
+      pageSize,
+      filters,
+      prismaFilters,
+    );
 
     return { results: projects, meta };
   }


### PR DESCRIPTION
- refactor: use full paths for the projects route
- feat: adapt the project services to accept filters
- feat: add get public projects route
- test: fix the tests after giving the projects services the ability to accept filters
- test: add more tests for the getProjects project service
- test: add more tests for the getSimplifiedProjects projects service
- test: add tests to the getPublicProjects projects controller
