### PR TITLE
feat!: add update project route

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@nestjs/core": "^10.0.0",
         "@nestjs/platform-express": "^10.0.0",
         "@nestjs/serve-static": "^4.0.2",
+        "@nestjs/swagger": "^7.4.2",
         "@prisma/client": "^5.20.0",
         "bcrypt": "^5.1.1",
         "chance": "^1.1.12",
@@ -2644,6 +2645,12 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.15.0.tgz",
+      "integrity": "sha512-HZpPoABogPvjeJOdzCOSJsXeL/SMCBgBZMVC3X3d7YYp2gf31MfxhUoYUNwf1ERPJOnQc0wkFn9trqI6ZEdZuA==",
+      "license": "MIT"
+    },
     "node_modules/@nestjs/cli": {
       "version": "10.4.5",
       "resolved": "https://registry.npmjs.org/@nestjs/cli/-/cli-10.4.5.tgz",
@@ -2842,6 +2849,26 @@
         }
       }
     },
+    "node_modules/@nestjs/mapped-types": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.0.5.tgz",
+      "integrity": "sha512-bSJv4pd6EY99NX9CjBIyn4TVDoSit82DUZlL4I3bqNfy5Gt+gXTa86i3I/i0iIV9P4hntcGM5GyO+FhZAhxtyg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nestjs/platform-express": {
       "version": "10.4.4",
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-10.4.4.tgz",
@@ -2991,6 +3018,39 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.2.5.tgz",
       "integrity": "sha512-l6qtdDPIkmAmzEO6egquYDfqQGPMRNGjYtrU13HAXb3YSRrt7HSb1sJY0pKp6o2bAa86tSB6iwaW2JbthPKr7Q==",
       "license": "MIT"
+    },
+    "node_modules/@nestjs/swagger": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-7.4.2.tgz",
+      "integrity": "sha512-Mu6TEn1M/owIvAx2B4DUQObQXqo2028R2s9rSZ/hJEgBK95+doTwS0DjmVA2wTeZTyVtXOoN7CsoM5pONBzvKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/tsdoc": "^0.15.0",
+        "@nestjs/mapped-types": "2.0.5",
+        "js-yaml": "4.1.0",
+        "lodash": "4.17.21",
+        "path-to-regexp": "3.3.0",
+        "swagger-ui-dist": "5.17.14"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^6.0.0 || ^7.0.0",
+        "@nestjs/common": "^9.0.0 || ^10.0.0",
+        "@nestjs/core": "^9.0.0 || ^10.0.0",
+        "class-transformer": "*",
+        "class-validator": "*",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@nestjs/testing": {
       "version": "10.4.4",
@@ -4896,7 +4956,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-flatten": {
@@ -8583,7 +8642,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -8795,7 +8853,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.includes": {
@@ -10779,6 +10836,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.17.14",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.17.14.tgz",
+      "integrity": "sha512-CVbSfaLpstV65OnSjbXfVd6Sta3q3F7Cj/yYuvHMp1P90LztOLs6PfUnKEVAeiIVQt9u2SaPwv0LiH/OyMjHRw==",
+      "license": "Apache-2.0"
     },
     "node_modules/symbol-observable": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@nestjs/core": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
     "@nestjs/serve-static": "^4.0.2",
+    "@nestjs/swagger": "^7.4.2",
     "@prisma/client": "^5.20.0",
     "bcrypt": "^5.1.1",
     "chance": "^1.1.12",

--- a/src/common/files.service.spec.ts
+++ b/src/common/files.service.spec.ts
@@ -31,6 +31,29 @@ describe('LocalFileService', () => {
       expect(fileExists).toEqual(true);
     });
   });
+
+  describe('delete', () => {
+    it('Should delete an existing file', async () => {
+      const file = readFileSync(resolve('test/data/photo.png'));
+      const name =
+        new Chance().string({ alpha: true, numeric: true, length: 16 }) +
+        '.png';
+      await service.upload(file, name, 'image/png');
+
+      await service.delete(name);
+
+      const fileExists = await exists(resolve('.temp/uploads', name));
+      expect(fileExists).toEqual(false);
+    });
+
+    it('Should not do anything if the file does not exist', async () => {
+      const fakeName =
+        new Chance().string({ alpha: true, numeric: true, length: 16 }) +
+        '.png';
+
+      await service.delete(fakeName);
+    });
+  });
 });
 
 describe('S3FileService', () => {

--- a/src/common/files.service.spec.ts
+++ b/src/common/files.service.spec.ts
@@ -21,7 +21,9 @@ describe('LocalFileService', () => {
   describe('upload', () => {
     it('Should upload a file to disk', async () => {
       const file = readFileSync(resolve('test/data/photo.png'));
-      const name = new Chance().string({ length: 16 }) + '.png';
+      const name =
+        new Chance().string({ alpha: true, numeric: true, length: 16 }) +
+        '.png';
 
       await service.upload(file, name, 'image/png');
 
@@ -47,7 +49,9 @@ describe('S3FileService', () => {
   describe('upload', () => {
     it('Should upload a file to S3', async () => {
       const file = readFileSync(resolve('test/data/photo.png'));
-      const name = new Chance().string({ length: 16 }) + '.png';
+      const name =
+        new Chance().string({ alpha: true, numeric: true, length: 16 }) +
+        '.png';
 
       await service.upload(file, name, 'image/png');
 

--- a/src/common/files.service.ts
+++ b/src/common/files.service.ts
@@ -1,9 +1,14 @@
-import { ensureDir, writeFile } from 'fs-extra';
+import { ensureDir, exists, rm, writeFile } from 'fs-extra';
 import { join, resolve } from 'path';
-import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import {
+  S3Client,
+  PutObjectCommand,
+  DeleteObjectCommand,
+} from '@aws-sdk/client-s3';
 
 export abstract class FileService {
   async upload(file: Buffer, name: string, mimeType: string) {}
+  async delete(path: string) {}
 }
 
 export class LocalFileService implements FileService {
@@ -13,6 +18,14 @@ export class LocalFileService implements FileService {
 
     const filePath = join(folderPath, name);
     await writeFile(filePath, file);
+  }
+
+  async delete(path: string) {
+    const filePath = resolve('.temp/uploads', path);
+
+    const fileExists = await exists(filePath);
+
+    if (fileExists) await rm(filePath);
   }
 }
 
@@ -39,5 +52,14 @@ export class S3FileService implements FileService {
     });
 
     await this.s3Client.send(uploadFileCommand);
+  }
+
+  async delete(path: string) {
+    const deleteCommand = new DeleteObjectCommand({
+      Bucket: process.env.S3_BUCKET,
+      Key: path,
+    });
+
+    await this.s3Client.send(deleteCommand);
   }
 }

--- a/src/common/files.service.ts
+++ b/src/common/files.service.ts
@@ -4,6 +4,7 @@ import {
   S3Client,
   PutObjectCommand,
   DeleteObjectCommand,
+  NotFound,
 } from '@aws-sdk/client-s3';
 
 export abstract class FileService {
@@ -60,6 +61,11 @@ export class S3FileService implements FileService {
       Key: path,
     });
 
-    await this.s3Client.send(deleteCommand);
+    try {
+      await this.s3Client.send(deleteCommand);
+    } catch (error) {
+      if (error instanceof NotFound) return;
+      throw error;
+    }
   }
 }

--- a/src/common/validation.exception.ts
+++ b/src/common/validation.exception.ts
@@ -5,6 +5,7 @@ export const validationMessages = {
   EMAIL_IN_USE: 'Emailul este deja asociat cu un cont',
   INVALID_CREDENTIALS: 'Adresa de email sau parola este incorecta',
   PROJECT_NOT_FOUND: 'Proiectul nu a fost gasit',
+  PHOTO_NOT_FOUND: 'Nu a fost gasita nicio poza cu acest nume',
 };
 
 export type ValidationExceptionCode = keyof typeof validationMessages;

--- a/src/projects/dto/update.dto.ts
+++ b/src/projects/dto/update.dto.ts
@@ -1,0 +1,19 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateProjectBody } from './create.dto';
+import { Transform } from 'class-transformer';
+import { IsArray, IsInt, IsOptional, IsString, Min } from 'class-validator';
+
+export class UpdateProjectParams {
+  @Transform(({ value }) => parseFloat(value))
+  @IsInt()
+  @Min(1)
+  id: number;
+}
+
+export class UpdateProjectBody extends PartialType(CreateProjectBody) {
+  /** The names of the photos to delete */
+  @IsArray()
+  @IsString({ each: true })
+  @IsOptional()
+  photosToDelete?: string[];
+}

--- a/src/projects/projects.controller.spec.ts
+++ b/src/projects/projects.controller.spec.ts
@@ -91,4 +91,21 @@ describe('ProjectsController', () => {
       expect(res.project).toEqual(result);
     });
   });
+
+  describe('updateProject', () => {
+    it('Should call the update project service and the send the project as a result', async () => {
+      const update = jest
+        .spyOn(projectsService as any, 'update')
+        .mockResolvedValue(undefined);
+
+      const params = {};
+      const body = {};
+      const photos = [];
+
+      const res = await controller.updateProject(params as any, body, photos);
+
+      expect(update).toHaveBeenCalled();
+      expect(res).toBeUndefined();
+    });
+  });
 });

--- a/src/projects/projects.controller.ts
+++ b/src/projects/projects.controller.ts
@@ -68,6 +68,7 @@ export class ProjectsController {
     return { project };
   }
 
+  @HttpCode(204)
   @Patch('/projects/:id')
   @UseGuards(AuthGuard)
   @UseInterceptors(FilesInterceptor('photos'))

--- a/src/projects/projects.controller.ts
+++ b/src/projects/projects.controller.ts
@@ -4,6 +4,7 @@ import {
   Get,
   HttpCode,
   Param,
+  Patch,
   Post,
   Query,
   UploadedFiles,
@@ -16,6 +17,7 @@ import { CreateProjectBody } from './dto/create.dto';
 import { AuthGuard } from '../common/auth.guard';
 import { GetProjectsQuery } from './dto/get.dto';
 import { GetProjectByIdParams } from './dto/get-by-id.dto';
+import { UpdateProjectBody, UpdateProjectParams } from './dto/update.dto';
 
 @Controller()
 export class ProjectsController {
@@ -64,5 +66,22 @@ export class ProjectsController {
   async getProjectById(@Param() params: GetProjectByIdParams) {
     const project = await this.projectsService.getProjectInfo(params.id);
     return { project };
+  }
+
+  @Patch('/projects/:id')
+  @UseGuards(AuthGuard)
+  @UseInterceptors(FilesInterceptor('photos'))
+  async updateProject(
+    @Param() params: UpdateProjectParams,
+    @Body() body: UpdateProjectBody,
+    @UploadedFiles() photos: Express.Multer.File[],
+  ) {
+    await this.projectsService.update(params.id, {
+      ...body,
+      photos: (photos || []).map((photo) => ({
+        content: photo.buffer,
+        mimeType: photo.mimetype,
+      })),
+    });
   }
 }

--- a/src/projects/projects.service.spec.ts
+++ b/src/projects/projects.service.spec.ts
@@ -533,4 +533,32 @@ describe('ProjectsService', () => {
       expect(remainingPhotosCount).toEqual(0);
     });
   });
+
+  describe('validateProjectId', () => {
+    it('Should not throw when the project exists', async () => {
+      const project = await service['prisma'].projects.create({
+        data: {
+          name: new Chance().string({ length: 32 }),
+          url: new Chance().url(),
+          active: new Chance().bool(),
+        },
+      });
+
+      let errors = 0;
+      try {
+        await service['validateProjectId'](project.id);
+      } catch {
+        errors++;
+      }
+      expect(errors).toEqual(0);
+    });
+
+    it('Should throw when the project does not exists', async () => {
+      const fakeProjectId = new Chance().integer({ min: 1, max: 1000 });
+
+      await expectValidationError('id', 'PROJECT_NOT_FOUND', () =>
+        service['validateProjectId'](fakeProjectId),
+      );
+    });
+  });
 });

--- a/src/projects/projects.service.ts
+++ b/src/projects/projects.service.ts
@@ -161,6 +161,31 @@ export class ProjectsService {
     return formattedProject;
   }
 
+  private async validatePhotoNames(projectId: number, photoNames: string[]) {
+    const existingPhotos = await this.prisma.projectPhotos.findMany({
+      select: {
+        name: true,
+      },
+      where: {
+        projectId,
+        name: {
+          in: photoNames,
+        },
+      },
+    });
+    const existingPhotosArray = existingPhotos.map((photo) => photo.name);
+
+    for (let i = 0; i < photoNames.length; i++) {
+      if (!existingPhotosArray.includes(photoNames[i])) {
+        throw ValidationException.fromCode(
+          'PHOTO_NOT_FOUND',
+          `photoNames.${i}`,
+        );
+      }
+    }
+  }
+
+
   private async validateProjectId(id: number) {
     const projectExists = await this.prisma.projects.findFirst({
       where: { id },

--- a/src/projects/projects.service.ts
+++ b/src/projects/projects.service.ts
@@ -151,9 +151,10 @@ export class ProjectsService {
     const formattedProject = merge(
       pick(project, ['id', 'name', 'url', 'description', 'active']),
       {
-        photos: project.photos
-          .map((photo) => photo.name)
-          .map((photoName) => this.getPhotoUrl(photoName)),
+        photos: project.photos.map((photo) => ({
+          name: photo.name,
+          url: this.getPhotoUrl(photo.name),
+        })),
       },
     );
 

--- a/src/projects/projects.service.ts
+++ b/src/projects/projects.service.ts
@@ -167,7 +167,11 @@ export class ProjectsService {
     return formattedProject;
   }
 
-  private async validatePhotoNames(projectId: number, photoNames: string[]) {
+  private async validatePhotoNames(
+    fieldName: string,
+    projectId: number,
+    photoNames: string[],
+  ) {
     const existingPhotos = await this.prisma.projectPhotos.findMany({
       select: {
         name: true,
@@ -185,7 +189,7 @@ export class ProjectsService {
       if (!existingPhotosArray.includes(photoNames[i])) {
         throw ValidationException.fromCode(
           'PHOTO_NOT_FOUND',
-          `photoNames.${i}`,
+          `${fieldName}.${i}`,
         );
       }
     }
@@ -216,7 +220,11 @@ export class ProjectsService {
 
   async update(id: number, updates: UpdateProjectData) {
     await this.validateProjectId(id);
-    await this.validatePhotoNames(id, updates.photosToDelete || []);
+    await this.validatePhotoNames(
+      'photosToDelete',
+      id,
+      updates.photosToDelete || [],
+    );
 
     await this.deletePhotos(updates.photosToDelete || []);
     await this.uploadPhotos(id, updates.photos || []);

--- a/src/projects/projects.service.ts
+++ b/src/projects/projects.service.ts
@@ -185,6 +185,17 @@ export class ProjectsService {
     }
   }
 
+  private async deletePhotos(photoNames: string[]) {
+    for (const name of photoNames) await this.fileService.delete(name);
+
+    await this.prisma.projectPhotos.deleteMany({
+      where: {
+        name: {
+          in: photoNames,
+        },
+      },
+    });
+  }
 
   private async validateProjectId(id: number) {
     const projectExists = await this.prisma.projects.findFirst({

--- a/src/projects/projects.service.ts
+++ b/src/projects/projects.service.ts
@@ -160,4 +160,15 @@ export class ProjectsService {
 
     return formattedProject;
   }
+
+  private async validateProjectId(id: number) {
+    const projectExists = await this.prisma.projects.findFirst({
+      where: { id },
+      select: { id: true },
+    });
+
+    if (!projectExists) {
+      throw ValidationException.fromCode('PROJECT_NOT_FOUND', 'id');
+    }
+  }
 }


### PR DESCRIPTION
- feat!: return the photo name and the photo url from the get project by id route
- feat: add update photo http validator
- feat: add delete photo file service
- feat: add validate project id project service
- feat: add validate photo names projects service
- feat: add delete photos projects service
- feat: add update project service
- feat: add update project controller
- fix: make the validatePhotoNames service accept the field name to throw if there is an error
- test: add tests for the validatePhotoNames service
- test: add tests for the deletePhotos projects service
- test: add tests for the validateProjectId service
- test: add tests for the update project service
- test: make sure the file names are only made out of alphanumeric characters when testing the file service
- test: add tests fo the delete local file service
- fix: make the delete s3 file service ignore the file not found errors
- test: add tests for the delete s3 file service
- test: add tests for the update project controller
- fix: make sure the update project route returns status 204
- test: add e2e tests for the update project route
